### PR TITLE
chore: Trim driver output

### DIFF
--- a/lib/gecko.js
+++ b/lib/gecko.js
@@ -89,8 +89,10 @@ class GeckoDriverProcess {
     }
     this.proc = new SubProcess(driverBin, args);
     this.proc.on('output', (stdout, stderr) => {
-      const line = stdout || stderr;
-      log.debug(`[${GD_BINARY}] ${line}`);
+      const line = _.trim(stdout || stderr);
+      if (line) {
+        log.debug(`[${GD_BINARY}] ${line}`);
+      }
     });
     this.proc.on('exit', (code, signal) => {
       log.info(`${GD_BINARY} has exited with code ${code}, signal ${signal}`);

--- a/lib/gecko.js
+++ b/lib/gecko.js
@@ -194,10 +194,12 @@ class GeckoDriverServer {
       return;
     }
 
-    try {
-      await this.proxy.command(`/session/${this.proxy.sessionId}`, 'DELETE');
-    } catch (e) {
-      log.info(`Gecko Driver session cannot be deleted. Original error: ${e.message}`);
+    if (this.proxy?.sessionId) {
+      try {
+        await this.proxy.command(`/session/${this.proxy.sessionId}`, 'DELETE');
+      } catch (e) {
+        log.info(`Gecko Driver session cannot be deleted. Original error: ${e.message}`);
+      }
     }
 
     try {


### PR DESCRIPTION
By default the driver prints too many empty lines 