### PR TITLE
chore: Make platformName capability values case-insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Gecko driver allows to define multiple criterions for platform selection and als
 
 Capability Name | Description
 --- | ---
-platformName | Gecko Driver supports the following platforms: `mac`, `linux`, `windows`. The fact your test must be executed on Android is detected based on `moz:firefoxOptions` entry values. Values of platformName are compared case-sensitively.
+platformName | Gecko Driver supports the following platforms: `mac`, `linux`, `windows`. The fact your test must be executed on Android is detected based on `moz:firefoxOptions` entry values. Values of platformName are compared case-insensitively.
 browserName | Any value passed to this capability will be changed to 'firefox'.
 browserVersion | Provide the version number of the browser to automate if there are multiple versions installed on the same machine where the driver is running.
 automationName | Must always be set to `Gecko`.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,6 +23,8 @@ function formatCapsForServer (caps) {
       result[name] = value;
     }
   }
+  // Geckodriver only supports lowercase platform names
+  result.platformName = _.toLower(result.platformName);
   return result;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,8 +23,10 @@ function formatCapsForServer (caps) {
       result[name] = value;
     }
   }
-  // Geckodriver only supports lowercase platform names
-  result.platformName = _.toLower(result.platformName);
+  if (result.platformName) {
+    // Geckodriver only supports lowercase platform names
+    result.platformName = _.toLower(result.platformName);
+  }
   return result;
 }
 

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -13,7 +13,7 @@ describe('formatCapsForServer', function () {
     const result = formatCapsForServer({
       browserName: 'yolo',
       browserVersion: '52',
-      platformName: 'mac',
+      platformName: 'Mac',
     });
     result.should.eql({
       browserName: 'firefox',


### PR DESCRIPTION
Safari driver already compares these values case-insensitively, which, I assume, is more flexible.