### PR TITLE
fix: Provide --marionette-port command line argument if --connect-existing is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ platformName | Gecko Driver supports the following platforms: `mac`, `linux`, `w
 browserName | Any value passed to this capability will be changed to 'firefox'.
 browserVersion | Provide the version number of the browser to automate if there are multiple versions installed on the same machine where the driver is running.
 automationName | Must always be set to `Gecko`.
-noReset | Being set to `true` adds the `--connect-existing` argument to the server, that allows to connect to an existing browser instance instead of starting a new browser instance on session startup.
+noReset | Being set to `true` adds the [--connect-existing](https://firefox-source-docs.mozilla.org/testing/geckodriver/Flags.html#code-connect-existing-code) argument to the server, that allows to connect to an existing browser instance instead of starting a new browser instance on session startup. You could also provide a custom value to `marionettePort` capability, otherwise the default value `2828` is going to be used.
+marionettePort | Selects the port for Geckodriver’s connection to the Marionette remote protocol. The existing Firefox instance must have Marionette enabled. To enable the remote protocol in Firefox, you can pass the `-marionette` flag. Unless the `marionette.port` preference has been user-set, Marionette will listen on port `2828`, which is the default value for this capability.
 systemPort | The number of the port for the driver to listen on. Must be unique for each session. If not provided then Appium will try to detect it automatically.
 verbosity | The verbosity level of driver logging. By default minimum verbosity is applied. Possible values are `debug` or `trace`.
 androidStorage | See https://firefox-source-docs.mozilla.org/testing/geckodriver/Flags.html#code-android-storage-var-android-storage-var-code

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -28,6 +28,9 @@ const desiredCapConstraints = {
   systemPort: {
     isNumber: true
   },
+  marionettePort: {
+    isNumber: true
+  },
   verbosity: {
     isString: true,
     inclusionCaseInsensitive: Object.values(VERBOSITY)

--- a/lib/gecko.js
+++ b/lib/gecko.js
@@ -92,6 +92,8 @@ class GeckoDriverProcess {
         log.info(`Assigning 'marionettePort' to the default value (${DEFAULT_MARIONETTE_PORT})`);
       }
       args.push('--marionette-port', this.marionettePort ?? DEFAULT_MARIONETTE_PORT);
+    } else if (!_.isNil(this.marionettePort)) {
+      args.push('--marionette-port', this.marionettePort);
     }
     /* #endregion */
 

--- a/lib/gecko.js
+++ b/lib/gecko.js
@@ -19,9 +19,13 @@ const GECKO_SERVER_GUARD = util.getLockFileGuard(
   {timeout: 5, tryRecovery: true}
 );
 const DEFAULT_MARIONETTE_PORT = 2828;
-const PROCESS_SPECIFIC_OPTION_NAMES = [
-  'noReset', 'verbosity', 'androidStorage', 'marionettePort'
-];
+const PROCESS_SPECIFIC_OPTION_NAMES_MAP = Object.freeze({
+  noReset: 'noReset',
+  verbosity: 'verbosity',
+  androidStorage: 'androidStorage',
+  marionettePort: 'marionettePort',
+  systemPort: 'port',
+});
 
 
 class GeckoProxy extends JWProxy {
@@ -37,10 +41,9 @@ class GeckoProxy extends JWProxy {
 
 class GeckoDriverProcess {
   constructor (opts = {}) {
-    for (const optName of PROCESS_SPECIFIC_OPTION_NAMES) {
-      this[optName] = opts[optName];
+    for (const [optName, propName] of _.toPairs(PROCESS_SPECIFIC_OPTION_NAMES_MAP)) {
+      this[propName] = opts[optName];
     }
-    this.port = opts.systemPort;
     this.proc = null;
   }
 

--- a/lib/gecko.js
+++ b/lib/gecko.js
@@ -18,6 +18,10 @@ const GECKO_SERVER_GUARD = util.getLockFileGuard(
   path.resolve(os.tmpdir(), 'gecko_server_guard.lock'),
   {timeout: 5, tryRecovery: true}
 );
+const DEFAULT_MARIONETTE_PORT = 2828;
+const PROCESS_SPECIFIC_OPTION_NAMES = [
+  'noReset', 'verbosity', 'androidStorage', 'marionettePort'
+];
 
 
 class GeckoProxy extends JWProxy {
@@ -33,7 +37,7 @@ class GeckoProxy extends JWProxy {
 
 class GeckoDriverProcess {
   constructor (opts = {}) {
-    for (const optName of ['noReset', 'verbosity', 'androidStorage']) {
+    for (const optName of PROCESS_SPECIFIC_OPTION_NAMES) {
       this[optName] = opts[optName];
     }
     this.port = opts.systemPort;
@@ -82,6 +86,12 @@ class GeckoDriverProcess {
     }
     if (this.noReset) {
       args.push('--connect-existing');
+      // https://firefox-source-docs.mozilla.org/testing/geckodriver/Flags.html#code-connect-existing-code
+      if (_.isNil(this.marionettePort)) {
+        log.info(`'marionettePort' capability value is not provided while 'noReset' is enabled`);
+        log.info(`Assigning 'marionettePort' to the default value (${DEFAULT_MARIONETTE_PORT})`);
+      }
+      args.push('--marionette-port', this.marionettePort ?? DEFAULT_MARIONETTE_PORT);
     }
     /* #endregion */
 


### PR DESCRIPTION
Addresses https://github.com/appium/appium-geckodriver/issues/20