### PR TITLE
feat: Update server compatibility

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -35,7 +35,8 @@ jobs:
     - run: sudo apt-get install firefox
       name: Install Firefox
     - run: |
-        npm install -g appium
+        appium_ver=$(node -p "require('./package.json').peerDependencies?.appium")
+        npm install -g "appium@$appium_ver"
         npm install
       name: Install dev dependencies
     - run: |

--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ This is Appium driver for automating Firefox on different platforms, including A
 The driver only supports Firefox and Gecko-based web views (Android only) automation using [W3C WebDriver protocol](https://www.w3.org/TR/webdriver/).
 Under the hood this driver is a wrapper/proxy over `geckodriver` binary. Check the driver [release notes](https://github.com/mozilla/geckodriver/releases) and the [official documentation](https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities) to get more details on the supported features and possible pitfalls.
 
-> **Note**
->
-> Since version 1.0.0 Gecko driver has dropped the support of Appium 1, and is only compatible to Appium 2. Use the `appium driver install gecko`
-> command to add it to your Appium 2 dist.
+> [!IMPORTANT]
+> Since major version *2.0.0*, this driver is only compatible with Appium 3. Use the `appium driver install gecko`
+> command to add it to your distribution.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "url": "https://github.com/appium/appium-geckodriver/issues"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=8"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   },
   "prettier": {
     "bracketSpacing": false,
@@ -58,7 +58,7 @@
     "appium": "^2.4.1"
   },
   "dependencies": {
-    "appium-adb": "^12.0.3",
+    "appium-adb": "^13.0.0",
     "asyncbox": "^3.0.0",
     "axios": "^1.7.7",
     "bluebird": "^3.5.1",
@@ -67,7 +67,7 @@
     "semver": "^7.6.3",
     "source-map-support": "^0.x",
     "tar-stream": "^3.1.7",
-    "teen_process": "^2.0.0"
+    "teen_process": "^3.0.0"
   },
   "scripts": {
     "build": "tsc -b",
@@ -82,16 +82,15 @@
     "e2e-test": "mocha --exit --timeout 5m \"./test/functional/**/*-specs.js\""
   },
   "devDependencies": {
-    "@appium/eslint-config-appium-ts": "^1.0.0",
-    "@appium/tsconfig": "^0.x",
-    "@appium/types": "^0.x",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
+    "@appium/tsconfig": "^1.0.0-rc.1",
+    "@appium/types": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/bluebird": "^3.5.38",
     "@types/lodash": "^4.14.196",
     "@types/mocha": "^10.0.1",
     "@types/node": "^22.0.0",
-    "@types/teen_process": "^2.0.2",
     "chai": "^5.1.1",
     "chai-as-promised": "^8.0.0",
     "conventional-changelog-conventionalcommits": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "scripts/*.mjs"
   ],
   "peerDependencies": {
-    "appium": "^2.4.1"
+    "appium": "^3.0.0-rc.2"
   },
   "dependencies": {
     "appium-adb": "^13.0.0",


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to ^20.19.0 || ^22.12.0 || >=24.0.0
BREAKING CHANGE: Required npm version has been bumped to >=10
BREAKING CHANGE: Required Appium server version has been bumped to >=3.0.0-rc.2