### PR TITLE
chore: drop rimraf deps from dev deps as no references

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "chai-as-promised": "^8.0.0",
     "conventional-changelog-conventionalcommits": "^8.0.0",
     "mocha": "^10.0.0",
-    "rimraf": "^5.0.0",
     "semantic-release": "^24.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.4.2",


### PR DESCRIPTION
```
kazu $ git grep 'rimraf'
CHANGELOG.md:* **deps-dev:** bump rimraf from 4.4.1 to 5.0.0 ([#52](https://github.com/appium/appium-geckodriver/issues/52)) ([95bbea2](https://github.com/appium/appium-geckodriver/commit/95bbea255b3679748058c709592f3100f7a18517))
CHANGELOG.md:* **deps-dev:** bump rimraf from 3.0.2 to 4.0.4 ([#49](https://github.com/appium/appium-geckodriver/issues/49)) ([ae37b96](https://github.com/appium/appium-geckodriver/commit/ae37b96bf0c77050e241d96d457cb1dabe26c6a9))
lib/utils.js:      await fs.rimraf(tmpRoot);
package.json:    "rimraf": "^5.0.0",
```

instead of https://github.com/appium/appium-geckodriver/pull/117