### PR TITLE
ci: remove firefox installation

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -32,8 +32,6 @@ jobs:
         sudo update-rc.d xvfb defaults
         sudo service xvfb start
       name: Start X virtual frame buffer
-    - run: sudo apt-get install firefox
-      name: Install Firefox
     - run: |
         appium_ver=$(node -p "require('./package.json').peerDependencies?.appium")
         npm install -g "appium@$appium_ver"


### PR DESCRIPTION
geckodriver and firefox are available natively. downloading geckodriver itself remains to test out the script.
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md