### PR TITLE
feat: Migrate package to ESM

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,4 +1,0 @@
-module.exports = {
-  require: ['ts-node/register'],
-  forbidOnly: Boolean(process.env.CI)
-};

--- a/lib/commands/find.ts
+++ b/lib/commands/find.ts
@@ -1,5 +1,5 @@
-import {util} from 'appium/support';
-import type {GeckoDriver} from '../driver';
+import {util} from 'appium/support.js';
+import type {GeckoDriver} from '../driver.js';
 
 /**
  * Find element(s) by given strategy and selector. If context is provided, search will be performed within the context element.

--- a/lib/desired-caps.ts
+++ b/lib/desired-caps.ts
@@ -1,5 +1,5 @@
 import type {Constraints} from '@appium/types';
-import {VERBOSITY} from './constants';
+import {VERBOSITY} from './constants.js';
 
 const DESIRED_CAP_CONSTRAINTS = {
   browserName: {

--- a/lib/doctor/required-checks.ts
+++ b/lib/doctor/required-checks.ts
@@ -1,4 +1,4 @@
-import {resolveExecutablePath} from './utils';
+import {resolveExecutablePath} from './utils.js';
 import {system, doctor} from '@appium/support';
 import type {AppiumLogger, IDoctorCheck} from '@appium/types';
 

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -6,12 +6,12 @@ import type {
   ExternalDriver,
   W3CDriverCaps,
 } from '@appium/types';
-import {BaseDriver, errors} from 'appium/driver';
-import {GECKO_SERVER_HOST, GeckoDriverServer} from './gecko';
-import {desiredCapConstraints} from './desired-caps';
-import {INSECURE_FEAT_CUSTOM_GECKODRIVER_EXECUTABLE} from './constants';
-import * as findCommands from './commands/find';
-import {formatCapsForServer} from './utils';
+import {BaseDriver, errors} from 'appium/driver.js';
+import {GECKO_SERVER_HOST, GeckoDriverServer} from './gecko.js';
+import {desiredCapConstraints} from './desired-caps.js';
+import {INSECURE_FEAT_CUSTOM_GECKODRIVER_EXECUTABLE} from './constants.js';
+import * as findCommands from './commands/find.js';
+import {formatCapsForServer} from './utils.js';
 
 const NO_PROXY: RouteMatcher[] = [
   ['GET', new RegExp('^/session/[^/]+/appium')],

--- a/lib/gecko.ts
+++ b/lib/gecko.ts
@@ -1,13 +1,13 @@
 import os from 'node:os';
 import path from 'node:path';
-import {JWProxy, errors} from 'appium/driver';
-import {fs, util, system} from 'appium/support';
+import {JWProxy, errors} from 'appium/driver.js';
+import {fs, util, system} from 'appium/support.js';
 import {SubProcess} from 'teen_process';
 import {waitForCondition} from 'asyncbox';
 import {findAPortNotInUse} from 'portscanner';
 import {execSync} from 'node:child_process';
 import type {AppiumLogger, StringRecord, HTTPMethod, HTTPBody} from '@appium/types';
-import {VERBOSITY} from './constants';
+import {VERBOSITY} from './constants.js';
 
 const GD_BINARY = `geckodriver${system.isWindows() ? '.exe' : ''}`;
 const STARTUP_TIMEOUT_MS = 10000; // 10 seconds

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-import {GeckoDriver} from './driver';
+import {GeckoDriver} from './driver.js';
 
 export default GeckoDriver;
 export {GeckoDriver};

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,4 +1,4 @@
-import {logger} from 'appium/support';
+import {logger} from 'appium/support.js';
 
 export const log = logger.getLogger('GeckoDriver');
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,9 +1,9 @@
-import {fs, net, zip, tempDir} from 'appium/support';
+import {fs, net, zip, tempDir} from 'appium/support.js';
 import tar from 'tar-stream';
 import zlib from 'node:zlib';
 import path from 'node:path';
 import type {StringRecord} from '@appium/types';
-import {STANDARD_CAPS} from 'appium/driver';
+import {STANDARD_CAPS} from 'appium/driver.js';
 
 const GECKO_CAP_PREFIXES = ['moz:'] as const;
 

--- a/package.json
+++ b/package.json
@@ -40,8 +40,15 @@
     },
     "mainClass": "GeckoDriver"
   },
+  "type": "module",
   "main": "./build/lib/index.js",
   "types": "./build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.js"
+    }
+  },
   "bin": {},
   "directories": {
     "lib": "lib"
@@ -76,8 +83,9 @@
     "prepare": "npm run build",
     "format": "prettier -w ./lib ./test",
     "format:check": "prettier --check ./lib ./test",
-    "test": "mocha --exit --timeout 1m \"./test/unit/**/*-specs.ts\"",
-    "e2e-test": "mocha --exit --timeout 5m \"./test/functional/**/*-specs.ts\""
+    "pretest": "npm run build",
+    "test": "node --test --test-timeout=60000 \"build/test/unit/**/*.test.js\"",
+    "e2e-test": "npm run build && node --test --test-timeout=300000 \"build/test/functional/**/*.test.js\""
   },
   "devDependencies": {
     "@appium/eslint-config-appium-ts": "^3.0.0",
@@ -85,19 +93,12 @@
     "@appium/types": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
-    "@types/chai": "^5.2.3",
-    "@types/chai-as-promised": "^8.0.2",
-    "@types/mocha": "^10.0.1",
     "@types/node": "^25.0.0",
     "@types/portscanner": "^2.1.4",
     "@types/tar-stream": "^3.1.4",
-    "chai": "^6.0.0",
-    "chai-as-promised": "^8.0.0",
     "conventional-changelog-conventionalcommits": "^9.1.0",
-    "mocha": "^11.7.1",
     "prettier": "^3.0.0",
     "semantic-release": "^25.0.2",
-    "ts-node": "^10.9.1",
     "typescript": "^6.0.2",
     "webdriverio": "^9.0.5"
   },

--- a/test/functional/desktop-driver-e2e.test.ts
+++ b/test/functional/desktop-driver-e2e.test.ts
@@ -1,11 +1,9 @@
+import {describe, it, beforeEach, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
 import {remote} from 'webdriverio';
-import {HOST, PORT, MOCHA_TIMEOUT, getPlatformName} from '../utils';
+import {HOST, PORT, TEST_TIMEOUT, getPlatformName} from '../utils.js';
 import {waitForCondition} from 'asyncbox';
 import type {Browser} from 'webdriverio';
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-
-chai.use(chaiAsPromised.default);
 
 const CAPS = {
   browserName: 'MozillaFirefox',
@@ -13,26 +11,24 @@ const CAPS = {
   'appium:automationName': 'Gecko',
 };
 
-describe('Desktop Gecko Driver', function () {
-  this.timeout(MOCHA_TIMEOUT);
-
+describe('Desktop Gecko Driver', {timeout: TEST_TIMEOUT}, () => {
   let driver: Browser | null = null;
 
-  beforeEach(async function () {
+  beforeEach(async () => {
     driver = await remote({
       hostname: HOST,
       port: PORT,
       capabilities: CAPS,
     });
   });
-  afterEach(async function () {
+  afterEach(async () => {
     if (driver) {
       await driver.deleteSession();
       driver = null;
     }
   });
 
-  it('should start and stop a session', async function () {
+  it('should start and stop a session', async () => {
     await driver!.url('https://appium.io/');
     try {
       await waitForCondition(
@@ -50,7 +46,7 @@ describe('Desktop Gecko Driver', function () {
         },
       );
     } catch {
-      this.fail('Timeout waiting for logo to load');
+      assert.fail('Timeout waiting for logo to load');
     }
   });
 });

--- a/test/functional/mobile-driver-e2e.test.ts
+++ b/test/functional/mobile-driver-e2e.test.ts
@@ -1,11 +1,9 @@
+import {describe, it, beforeEach, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
 import {remote} from 'webdriverio';
-import {HOST, PORT, MOCHA_TIMEOUT, getPlatformName} from '../utils';
+import {HOST, PORT, TEST_TIMEOUT, getPlatformName} from '../utils.js';
 import {waitForCondition} from 'asyncbox';
 import type {Browser} from 'webdriverio';
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-
-chai.use(chaiAsPromised.default);
 
 const DEVICE_NAME = process.env.DEVICE_NAME || 'emulator-5554';
 // The Firefox binary could be retrieved from https://www.mozilla.org/en-GB/firefox/all/#product-android-release
@@ -20,32 +18,26 @@ const CAPS = {
   'appium:androidStorage': 'internal',
 } as any;
 
-describe('Mobile GeckoDriver', function () {
-  this.timeout(MOCHA_TIMEOUT);
+const describeMobile = process.env.CI ? describe.skip : describe;
 
+describeMobile('Mobile GeckoDriver', {timeout: TEST_TIMEOUT}, () => {
   let driver: Browser | null = null;
 
-  before(async function () {
-    if (process.env.CI) {
-      // Figure out a way to run this on Azure
-      return this.skip();
-    }
-  });
-  beforeEach(async function () {
+  beforeEach(async () => {
     driver = await remote({
       hostname: HOST,
       port: PORT,
       capabilities: CAPS,
     });
   });
-  afterEach(async function () {
+  afterEach(async () => {
     if (driver) {
       await driver.deleteSession();
       driver = null;
     }
   });
 
-  it('should start and stop a session', async function () {
+  it('should start and stop a session', async () => {
     await driver!.url('https://appium.io/');
     try {
       await waitForCondition(
@@ -63,7 +55,7 @@ describe('Mobile GeckoDriver', function () {
         },
       );
     } catch {
-      this.fail('Timeout waiting for download button to load');
+      assert.fail('Timeout waiting for download button to load');
     }
   });
 });

--- a/test/unit/driver-specs.ts
+++ b/test/unit/driver-specs.ts
@@ -1,8 +1,0 @@
-import {GeckoDriver} from '../../lib/driver';
-import {expect} from 'chai';
-
-describe('GeckoDriver', function () {
-  it('should exist', function () {
-    expect(GeckoDriver).to.exist;
-  });
-});

--- a/test/unit/driver.test.ts
+++ b/test/unit/driver.test.ts
@@ -1,0 +1,9 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import {GeckoDriver} from '../../lib/driver.js';
+
+describe('GeckoDriver', () => {
+  it('should exist', () => {
+    assert.ok(GeckoDriver);
+  });
+});

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,26 +1,27 @@
-import {formatCapsForServer} from '../../lib/utils';
-import {expect} from 'chai';
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import {formatCapsForServer} from '../../lib/utils.js';
 
-describe('formatCapsForServer', function () {
-  it('should format empty caps', function () {
+describe('formatCapsForServer', () => {
+  it('should format empty caps', () => {
     const result = formatCapsForServer({});
-    expect(result).to.eql({});
+    assert.deepEqual(result, {});
   });
 
-  it('should assign default caps', function () {
+  it('should assign default caps', () => {
     const result = formatCapsForServer({
       browserName: 'yolo',
       browserVersion: '52',
       platformName: 'Mac',
     });
-    expect(result).to.eql({
+    assert.deepEqual(result, {
       browserName: 'firefox',
       browserVersion: '52',
       platformName: 'mac',
     });
   });
 
-  it('should only pass caps with supported prefixes', function () {
+  it('should only pass caps with supported prefixes', () => {
     const result = formatCapsForServer({
       browserVersion: '52',
       bar: '67',
@@ -28,7 +29,7 @@ describe('formatCapsForServer', function () {
       'webkit:yolo': '567',
       'appium:bar': '789',
     });
-    expect(result).to.eql({
+    assert.deepEqual(result, {
       browserVersion: '52',
       'moz:foo': '1234',
     });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,9 +1,9 @@
 export const HOST = process.env.APPIUM_TEST_SERVER_HOST || '127.0.0.1';
 export const PORT = parseInt(process.env.APPIUM_TEST_SERVER_PORT || '4567', 10);
-export const MOCHA_TIMEOUT = 240000;
+export const TEST_TIMEOUT = 240000;
 
 /**
- * @returns {'mac' | 'linux' | 'windows'} The platform name for driver capabilities
+ * @returns The platform name for driver capabilities
  */
 export function getPlatformName(): 'mac' | 'linux' | 'windows' {
   switch (process.platform) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,15 +3,12 @@
   "extends": "@appium/tsconfig/tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "types": ["node", "mocha"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": ".",
+    "types": ["node"],
     "checkJs": true,
     "strict": true
-  },
-  "ts-node": {
-    "transpileOnly": true,
-    "compilerOptions": {
-      "rootDir": "."
-    }
   },
   "include": [
     "lib",


### PR DESCRIPTION
BREAKING CHANGE: Migrate the package to native ESM (`"type": "module"`, `exports` map, `NodeNext` TypeScript output, `.js` import extensions, `appium/driver.js` / `appium/support.js` subpath imports). Consumers using `require()` against deep/internal paths will need to switch to ESM `import` or use the published `exports` entry point.

## Other changes

### Testing
- Removed Mocha, Chai, `chai-as-promised`, `ts-node`, and related `@types/*` packages.
- Unit tests: `node --test build/test/unit/**/*.test.js`
- E2E tests: `node --test build/test/functional/**/*.test.js`
- Removed `.mocharc.js`
