### PR TITLE
feat: add 5 Firefox WebDriver endpoints

### DIFF
--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -9,6 +9,7 @@ import type {
 import {BaseDriver, errors} from 'appium/driver';
 import {GECKO_SERVER_HOST, GeckoDriverServer} from './gecko';
 import {desiredCapConstraints} from './desired-caps';
+import {newMethodMap} from './method-map';
 import {INSECURE_FEAT_CUSTOM_GECKODRIVER_EXECUTABLE} from './constants';
 import * as findCommands from './commands/find';
 import {formatCapsForServer} from './utils';
@@ -26,6 +27,8 @@ export class GeckoDriver
   extends BaseDriver<GeckoConstraints, StringRecord>
   implements ExternalDriver<GeckoConstraints, string, StringRecord>
 {
+  static newMethodMap = newMethodMap;
+
   public proxyReqRes: (...args: any) => any = null as any;
 
   findElOrEls = findCommands.findElOrEls;

--- a/lib/method-map.ts
+++ b/lib/method-map.ts
@@ -18,7 +18,11 @@ export const newMethodMap = {
   '/session/:sessionId/moz/addon/install': {
     POST: {
       command: 'installAddon',
-      payloadParams: {required: ['addon'], optional: ['temporary', 'allowPrivateBrowsing']},
+      payloadParams: {
+        validate: (payloadData) =>
+          !payloadData.addon && !payloadData.path && "Either 'addon' or 'path' must be provided",
+        optional: ['addon', 'path', 'temporary', 'allowPrivateBrowsing'],
+      },
     },
   },
   '/session/:sessionId/moz/addon/uninstall': {

--- a/lib/method-map.ts
+++ b/lib/method-map.ts
@@ -1,0 +1,35 @@
+import type {MethodMap} from '@appium/types';
+import type {GeckoDriver} from './driver';
+
+export const newMethodMap = {
+  /**
+   * Firefox vendor-specific endpoints
+   * https://github.com/mozilla-firefox/firefox/blob/main/testing/geckodriver/src/command.rs
+   */
+  '/session/:sessionId/moz/context': {
+    GET: {
+      command: 'getContext',
+    },
+    POST: {
+      command: 'setContext',
+      payloadParams: {required: ['context']},
+    },
+  },
+  '/session/:sessionId/moz/addon/install': {
+    POST: {
+      command: 'installAddon',
+      payloadParams: {required: ['addon'], optional: ['temporary', 'allowPrivateBrowsing']},
+    },
+  },
+  '/session/:sessionId/moz/addon/uninstall': {
+    POST: {
+      command: 'uninstallAddon',
+      payloadParams: {required: ['id']},
+    },
+  },
+  '/session/:sessionId/moz/screenshot/full': {
+    GET: {
+      command: 'takeFullScreenshot',
+    },
+  },
+} as const satisfies MethodMap<GeckoDriver>;


### PR DESCRIPTION
This PR adds support for 5 Firefox-specific WebDriver endpoints.

I tested the two GET endpoints over `curl` and they worked as expected, whereas previously they were returning the `unknown command` error.