### PR TITLE
fix: Export package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     ".": {
       "types": "./build/lib/index.d.ts",
       "import": "./build/lib/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "bin": {},
   "directories": {


### PR DESCRIPTION
Fixes [install error](https://github.com/appium/appium/issues/22387): 

Error: ✖ Encountered an error when installing package: Package subpath './package.json' is not defined by "exports" in /Users/elf/.appium/node_modules/appium-geckodriver/package.json