### PR TITLE
docs: add info on starting a basic session

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -73,3 +73,24 @@ The server log output should include a line like the following:
 ```
 [Appium] GeckoDriver has been successfully loaded in 0.789s
 ```
+
+## Creating a Session
+
+Appium Geckodriver, like all Appium drivers, requires providing [specific capabilities](https://appium.io/docs/en/latest/guides/caps/)
+in order to start a new session. The following example lists the minimum required capabilities for
+a basic session:
+
+```json
+// This will launch Firefox on the host machine and attach to it
+{
+  ...
+  "platformName": "mac", // "mac", "windows", or "linux"
+  "appium:automationName": "gecko",
+  ...
+}
+```
+
+For testing on an Android device, additional capabilities are required - refer to [the Android testing guide](../guides/android.md).
+
+See [the Capabilities reference page](../reference/capabilities.md) for more information on the
+capabilities supported by the driver.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -25,8 +25,9 @@ Refer to the [Non-Firefox Browsers guide](./guides/other-browsers.md) for more d
 
 ## Technologies Used
 
-Under the hood, Appium Geckodriver is a wrapper/proxy over Mozilla's `geckodriver` binary. Learn
-more about its features here:
+Appium Geckodriver uses the [W3C WebDriver protocol](https://www.w3.org/TR/webdriver/) for session
+management. Under the hood, the driver is a wrapper/proxy over Mozilla's `geckodriver` binary.
+Learn more about its features here:
 
 * [`geckodriver` documentation](https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html)
 * [`geckodriver` release notes](https://github.com/mozilla/geckodriver/releases)


### PR DESCRIPTION
Minor tune-up of the docs before I begin working on the next driver.

* Add a new section in Getting Started about how to start a basic session
* Add info about the driver using the WebDriver protocol (this was previously in the README)