### PR TITLE
chore: downgrade conventional-changelog-conventionalcommits to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@types/node": "^26.0.0",
     "@types/portscanner": "^2.1.4",
     "@types/tar-stream": "^3.1.4",
-    "conventional-changelog-conventionalcommits": "^10.2.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "prettier": "^3.0.0",
     "semantic-release": "^25.0.2",
     "typescript": "^6.0.2",


### PR DESCRIPTION
https://github.com/appium/appium-safari-driver/pull/177